### PR TITLE
new delete_multiple_objects() method

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,8 @@ requires 'HTTP::Date';
 requires 'MIME::Base64';
 requires 'LWP::UserAgent';
 requires 'URI::Escape';
+requires 'Encode';
+requires 'Digest::MD5';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -148,6 +148,41 @@ sub list_objects {
     return $response;
 }
 
+sub delete_multiple_objects {
+    my ($self, $bucket, @keys) = @_;
+
+    my $content = _build_xml_for_delete( @keys );
+
+    require Digest::MD5;
+    my $request = $self->_compose_request(
+        'POST',
+        "$bucket/?delete",
+        {
+            'Content-MD5'    => Digest::MD5::md5_base64($content) . '==',
+            'Content-Length' => length $content,
+        },
+        $content
+    );
+    my $response = $self->ua->request($request);
+    return $response;
+}
+
+sub _build_xml_for_delete {
+    my (@keys) = @_;
+
+    require Encode;
+    my $content = '<Delete><Quiet>true</Quiet>';
+
+    foreach my $k (@keys) {
+        $content .= '<Object><Key>'
+                  . Encode::encode('UTF-8', $k)
+                  . '</Key></Object>';
+    }
+    $content .= '</Delete>';
+
+    return $content;
+}
+
 sub _uri {
     my ($self, $bucket, $key) = @_;
     return ($key)
@@ -263,6 +298,8 @@ Amazon::S3::Thin - A thin, lightweight, low-level Amazon S3 client
   print $response->content; # => "hello world"
 
   $response = $s3client->delete_object($bucket, $key);
+
+  $response = $s3client->delete_multiple_objects( $bucket, @keys );
 
   $response = $s3client->copy_object($src_bucket, $src_key,
                                      $dst_bucket, $dst_key);
@@ -444,6 +481,21 @@ object to the bucket.
 For more information, please refer to
 L<< Amazon's documentation for PUT|http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html >>.
 
+=head2 delete_multiple_objects( $bucket, @keys )
+
+B<Arguments>: a string with the bucket name, and an array with all the keys
+to be deleted.
+
+B<Returns>: an L<HTTP::Response> object for the request.
+
+The Multi-Object Delete operation enables you to delete multiple objects
+(up to 1000) from a bucket using a single HTTP request. If you know the
+object keys that you want to delete, then this operation provides a suitable
+alternative to sending individual delete requests with C<delete_object()>,
+reducing per-request overhead.
+
+For more information, please refer to
+L<< Amazon's documentation for DELETE multiple objects|http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html >>.
 
 =head1 TODO
 

--- a/t/01_request.t
+++ b/t/01_request.t
@@ -47,6 +47,12 @@ my $req4 = $res4->request;
 is $req4->method, "GET";
 is $req4->uri, "http://tmpfoobar.s3.amazonaws.com/?delimiter=%2F&prefix=12012";
 
+diag "test POST for delete_multiple_objects";
+my $res5 = $client->delete_multiple_objects( $bucket, 'key/one.txt', 'key/two.png' );
+my $req5 = $res5->request;
+is $req5->method, "POST";
+is $req5->uri, "http://tmpfoobar.s3.amazonaws.com/?delete";
+is $req5->header('Content-MD5'), 'pjGVehBgNtca8xN21pLCCA==';
 
 done_testing;
 


### PR DESCRIPTION
Hi! Me again :)

While I was coding a project that uses Amazon::S3::Thin, I realized if I wanted to delete an entire "tree" (or key prefix in S3 terms), I could fetch all keys using `list_objects()`, but I'd have to send one `delete_object()` request per key, which would definitely slow things down!

Fortunately, the REST API provides the "[DELETE multi objects](http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html)" endpoint for us, so I went ahead and implemented it :)

As usual, this PR also contains testing code and documentation. In order to be fully compliant with Amazon's API I had to depend on "Encode" and "Digest::MD5", both core modules since forever and loaded (via require) only on demand, during runtime, so it would not bloat the class.

The code works like a charm and I'm using it in production, so if there's anything I can do to help you push this to CPAN, please don't hesitate and just let me know :)

Cheers! And thanks again for all the great work!