### PR TITLE
allow headers to be passed to get_object()

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,15 @@ compatible with [LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) (i.e. 
 
 # METHODS
 
-## get\_object( $bucket, $key )
+## get\_object( $bucket, $key \[, $headers\] )
 
-**Arguments**: a string with the bucket name, and a string with the key name.
+**Arguments**: 
+
+a list of the following items, in order:
+
+- 1. bucket - a string with the bucket
+- 2. key - a string with the key
+- 3. headers (**optional**) - hashref with extra headr information
 
 **Returns**: an [HTTP::Response](https://metacpan.org/pod/HTTP::Response) object for the request. Use the `content()`
 method on the returned object to read the contents:

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -74,8 +74,8 @@ sub ua {
 }
 
 sub get_object {
-    my ($self, $bucket, $key) = @_;
-    my $request = $self->_compose_request('GET', $self->_uri($bucket, $key));
+    my ($self, $bucket, $key, $headers) = @_;
+    my $request = $self->_compose_request('GET', $self->_uri($bucket, $key), $headers);
     return $self->ua->request($request);
 }
 
@@ -406,9 +406,21 @@ compatible with L<LWP::UserAgent> (i.e. providing the same interface).
 
 =head1 METHODS
 
-=head2 get_object( $bucket, $key )
+=head2 get_object( $bucket, $key [, $headers] )
 
-B<Arguments>: a string with the bucket name, and a string with the key name.
+B<Arguments>:
+
+a list of the following items, in order:
+
+=over 3
+
+=item 1. bucket - a string with the bucket
+
+=item 2. key - a string with the key
+
+=item 3. headers (B<optional>) - hashref with extra headr information
+
+=back
 
 B<Returns>: an L<HTTP::Response> object for the request. Use the C<content()>
 method on the returned object to read the contents:

--- a/t/01_request.t
+++ b/t/01_request.t
@@ -32,7 +32,6 @@ is $req1->method, "PUT";
 is $req1->content, $body;
 is $req1->uri, "http://tmpfoobar.s3.amazonaws.com/dir%2Fprivate%2Etxt";
 
-
 diag "test GET request";
 is $req2->method, "GET";
 is $req2->uri, "http://tmpfoobar.s3.amazonaws.com/dir%2Fprivate%2Etxt";
@@ -53,6 +52,13 @@ my $req5 = $res5->request;
 is $req5->method, "POST";
 is $req5->uri, "http://tmpfoobar.s3.amazonaws.com/?delete";
 is $req5->header('Content-MD5'), 'pjGVehBgNtca8xN21pLCCA==';
+
+diag "test GET request with headers";
+my $res6 = $client->get_object($bucket, $key, {"X-Test-Header" => "Foo"});
+my $req6 = $res6->request;
+is $req6->method, "GET";
+is $req6->uri, "http://tmpfoobar.s3.amazonaws.com/dir%2Fprivate%2Etxt";
+is $req6->header("X-Test-Header"), "Foo";
 
 done_testing;
 


### PR DESCRIPTION
These changes allow the caller to pass custom headers to get_object. This is necessary to use the S3 client with temporary security credentials, which requires the x-amz-security-token header to be passed and included in the signature.

Per the amazon docs (http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html):

> If you are signing your request using temporary security credentials (see Making Requests), you must include the corresponding security token in your request by adding the x-amz-security-token header.

I tried just passing in a UA w/ x-amz-security-token set as a default header, but that won't work because that header would not be signed in the request.