### PR TITLE
Remove extraneous debug hooks

### DIFF
--- a/lib/Amazon/S3/Thin/Signer/V4.pm
+++ b/lib/Amazon/S3/Thin/Signer/V4.pm
@@ -49,7 +49,6 @@ sub sign
   my $signer = $self->signer;
   my $digest = Digest::SHA::sha256_hex($request->content);
   $request->header('X-Amz-Content-SHA256', $digest);
-  $DB::single = 1;
   $signer->sign($request, $self->{region}, $digest);
   $request;
 }

--- a/t/01_signer_v4.t
+++ b/t/01_signer_v4.t
@@ -14,7 +14,6 @@ use HTTP::Request;
       aws_secret_access_key => 'secretkey',
     });
   $signer->sign($request);
-  $DB::single = 1;
   my $headers = [ sort split /\n/, $request->headers->as_string ];
   is_deeply ($headers, [
       'Authorization: AWS4-HMAC-SHA256 Credential=accesskey/20070328/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=0dea3c9b65eede067ce9e38d48558a63924a6a08a8d21c27cfd7de50e5c78d4b',


### PR DESCRIPTION
I stupidly left two `$DB::single = 1` hooks in my previous PR. These won't affect normal operation, but will probably annoy users trying to debug other code.