### PR TITLE
copy_object() takes optional headers

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl extension Amazon-S3-Thin
 
 {{$NEXT}}
    - documented on head_object()
+   - copy_object() takes optional headers
 
 0.23 2018-09-03T15:30:25Z
    - Add Config::Tiny in PREREQ_PM of Makefile.PL to pass test

--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ Use the response object to see if it succeeded or not.
 For more information, please refer to
 [Amazon's documentation for DELETE](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html).
 
-## copy\_object( $src\_bucket, $src\_key, $dst\_bucket, $dst\_key )
+## copy\_object( $src\_bucket, $src\_key, $dst\_bucket, $dst\_key \[, $headers\] )
 
-**Arguments**: a list with source (bucket, key) and destination (bucket, key)
+**Arguments**: a list with source (bucket, key) and destination (bucket, key), hashref with extra header information (**optional**).
 
 **Returns**: an [HTTP::Response](https://metacpan.org/pod/HTTP::Response) object for the request.
 

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -129,8 +129,8 @@ sub delete_object {
 }
 
 sub copy_object {
-    my ($self, $src_bucket, $src_key, $dst_bucket, $dst_key) = @_;
-    my $headers = {};
+    my ($self, $src_bucket, $src_key, $dst_bucket, $dst_key, $headers) = @_;
+    $headers ||= {};
     $headers->{'x-amz-copy-source'} = $src_bucket . "/" . $src_key;
     my $request = $self->_compose_request('PUT', $self->_resource($dst_bucket, $dst_key), $headers);
     return $self->_send($request);
@@ -544,9 +544,9 @@ Use the response object to see if it succeeded or not.
 For more information, please refer to
 L<< Amazon's documentation for DELETE|http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html >>.
 
-=head2 copy_object( $src_bucket, $src_key, $dst_bucket, $dst_key )
+=head2 copy_object( $src_bucket, $src_key, $dst_bucket, $dst_key [, $headers] )
 
-B<Arguments>: a list with source (bucket, key) and destination (bucket, key)
+B<Arguments>: a list with source (bucket, key) and destination (bucket, key), hashref with extra header information (B<optional>).
 
 B<Returns>: an L<HTTP::Response> object for the request.
 

--- a/t/03_request.t
+++ b/t/03_request.t
@@ -61,6 +61,14 @@ is $req6->method, "GET";
 is $req6->uri, "http://s3.ap-north-east-1.amazonaws.com/tmpfoobar/dir/private.txt";
 is $req6->header("X-Test-Header"), "Foo";
 
+diag "test PUT request (copy) with headers";
+my $res7 = $client->copy_object($bucket, $key, $bucket, "copied.txt", {"x-amz-acl" => "public-read"});
+my $req7 = $res7->request;
+is $req7->method, "PUT";
+is $req7->uri, "http://s3.ap-north-east-1.amazonaws.com/tmpfoobar/copied.txt";
+is $req7->header("x-amz-copy-source"), "tmpfoobar/dir/private.txt";
+is $req7->header("x-amz-acl"), "public-read";
+
 done_testing;
 
 package MockUA;


### PR DESCRIPTION
These changes copy_object() can be take optional headers in arguments. This allows to pass metadata on PUT (copy) request.