### PR TITLE
support aws_session_token

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Amazon-S3-Thin
 
 {{$NEXT}}
+   - support aws_session_token
 
 0.24 2019-06-05T07:33:37Z
    - documented on head_object()

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -25,10 +25,12 @@ sub new {
     # wrap credentials
     $self->{credentials} = Amazon::S3::Thin::Credentials->new(
         $self->{aws_access_key_id},
-        $self->{aws_secret_access_key}
+        $self->{aws_secret_access_key},
+        $self->{aws_session_token},
     );
     delete $self->{aws_access_key_id};
     delete $self->{aws_secret_access_key};
+    delete $self->{aws_session_token};
 
     bless $self, $class;
 
@@ -320,6 +322,7 @@ Amazon::S3::Thin - A thin, lightweight, low-level Amazon S3 client
   my $s3client = Amazon::S3::Thin->new({
         aws_access_key_id     => $aws_access_key_id,
         aws_secret_access_key => $aws_secret_access_key,
+        aws_session_token     => $aws_session_token, # optional
         region                => $region, # e.g. 'ap-northeast-1'
       });
 

--- a/lib/Amazon/S3/Thin/Credentials.pm
+++ b/lib/Amazon/S3/Thin/Credentials.pm
@@ -7,11 +7,14 @@ Amazon::S3::Thin::Credentials - AWS credentials data container
 =head1 SYNOPSIS
 
     my $credentials = Amazon::S3::Thin::Credentials->new(
-        $aws_access_key_id, $aws_secret_access_key
+        $aws_access_key_id, $aws_secret_access_key,
+        # optional:
+        $aws_session_token
     );
     
     my $key = $credentials->access_key_id();
     my $secret = $credentials->secret_access_key();
+    my $session_token = $credentials->session_token();
 
 1;
 
@@ -25,10 +28,11 @@ use strict;
 use warnings;
 
 sub new {
-    my ($class, $key, $secret) = @_;
+    my ($class, $key, $secret, $session_token) = @_;
     my $self = {
         key => $key,
         secret => $secret,
+        session_token => $session_token,
     };
     return bless $self, $class;
 }
@@ -53,6 +57,17 @@ Returns secret_access_key
 sub secret_access_key {
     my $self = shift;
     return $self->{secret};
+}
+
+=head2 session_token()
+
+Returns session_token
+
+=cut
+
+sub session_token {
+    my $self = shift;
+    return $self->{session_token};
 }
 
 1;

--- a/lib/Amazon/S3/Thin/Signer/V2.pm
+++ b/lib/Amazon/S3/Thin/Signer/V2.pm
@@ -31,6 +31,9 @@ sub sign
 {
   my ($self, $request) = @_;
   $request->header(Date => HTTP::Date::time2str(time)) unless $request->header('Date');
+  if (defined $self->{credentials}->session_token) {
+    $request->header('X-Amz-Security-Token', $self->{credentials}->session_token);
+  }
   my $host = $request->uri->host;
   my $bucket = substr($host, 0, length($host) - length($self->{host}) - 1);
   my $path = $bucket . $request->uri->path;

--- a/lib/Amazon/S3/Thin/Signer/V4.pm
+++ b/lib/Amazon/S3/Thin/Signer/V4.pm
@@ -53,6 +53,9 @@ sub sign
 {
   my ($self, $request) = @_;
   my $signer = $self->signer;
+  if (defined $self->{credentials}->session_token) {
+    $request->header('X-Amz-Security-Token', $self->{credentials}->session_token);
+  }
   my $digest = Digest::SHA::sha256_hex($request->content);
   $request->header('X-Amz-Content-SHA256', $digest);
   $signer->sign($request, $self->{region}, $digest);

--- a/t/02_signer_v2.t
+++ b/t/02_signer_v2.t
@@ -288,4 +288,21 @@ my $credentials = Amazon::S3::Thin::Credentials->new('', $secret);
     }, 'Request headers');
 }
 
+{
+    diag "test sign (session token)";
+
+    my $request = HTTP::Request->new(GET => 'https://mybucket.s3.amazonaws.com/myfile.txt');
+    $request->header('Date' => 'Wed, 28 Mar 2007 01:49:49 +0000');
+    my $credentials = Amazon::S3::Thin::Credentials->new('accesskey', 'secretkey', 'sessiontoken');
+    my $signer = Amazon::S3::Thin::Signer::V2->new($credentials, 's3.amazonaws.com');
+    $signer->sign($request);
+    my $headers = $request->headers;
+    delete $headers->{'::std_case'};
+    is_deeply ($headers, {
+        authorization => 'AWS accesskey:jALzlsXtPsSS7qFbE7l2f7Dpx5Y=',
+        date => 'Wed, 28 Mar 2007 01:49:49 +0000',
+        'x-amz-security-token' => 'sessiontoken',
+    }, 'Request headers');
+}
+
 done_testing;

--- a/t/02_signer_v4.t
+++ b/t/02_signer_v4.t
@@ -36,4 +36,23 @@ my $credentials = Amazon::S3::Thin::Credentials->new('accesskey', 'secretkey');
     ], 'Request headers');
 }
 
+{
+    diag "test sign (session token)";
+
+    my $request = HTTP::Request->new(GET => 'https://mybucket.s3.amazonaws.com/myfile.txt');
+    $request->header('Date' => 'Wed, 28 Mar 2007 01:49:49 +0000');
+    my $credentials = Amazon::S3::Thin::Credentials->new('accesskey', 'secretkey', 'sessiontoken');
+    my $signer = Amazon::S3::Thin::Signer::V4->new($credentials);
+    $signer->sign($request);
+    my $headers = [ sort split /\n/, $request->headers->as_string ];
+    is_deeply ($headers, [
+        'Authorization: AWS4-HMAC-SHA256 Credential=accesskey/20070328/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=54a046a4241ef546a30aec8d9e9a1e91c2d095be24baaef1797350cd2cfef2fd',
+        'Date: Wed, 28 Mar 2007 01:49:49 +0000',
+        'Host: mybucket.s3.amazonaws.com',
+        'X-Amz-Content-SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        'X-Amz-Date: 20070328T014949Z',
+        'X-Amz-Security-Token: sessiontoken',
+    ], 'Request headers');
+}
+
 done_testing;


### PR DESCRIPTION
`Amazon::S3::Thin->new` now takes temporary security credentials as an optional `aws_session_token` parameter.

https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html