### PR TITLE
Support virtual-hosted style request

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Amazon-S3-Thin
 
 {{$NEXT}}
 
+   - [core] support virtual-hosted style request
+
 0.26 2019-11-26T14:24:41Z
 
    - require Config::Tiny on test

--- a/lib/Amazon/S3/Thin/Resource.pm
+++ b/lib/Amazon/S3/Thin/Resource.pm
@@ -37,6 +37,16 @@ sub to_path_style_url {
     );
 }
 
+sub to_virtual_hosted_style_url {
+    my $self = shift;
+    my $protocol = shift;
+    return $self->_composer_url(
+        $protocol,
+        sprintf("%s.s3.amazonaws.com", $self->{bucket}),
+        $self->key_and_query
+    );
+}
+
 sub _region_specific_host {
     my $self = shift;
     my $region = shift;

--- a/t/06_request_virtual_host.t
+++ b/t/06_request_virtual_host.t
@@ -1,0 +1,100 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Data::Dumper;
+use Amazon::S3::Thin;
+use Test::More;
+
+my $arg = +{
+    aws_access_key_id     => "dummy",
+    aws_secret_access_key => "dummy",
+    region => 'ap-north-east-1',
+    virtual_host => 1,
+};
+
+$arg->{ua} = MockUA->new;
+my $client = Amazon::S3::Thin->new($arg);
+
+my $bucket = "tmpfoobar";
+my $key =  "dir/private.txt";
+my $body = "hello world";
+
+my $res1 = $client->put_object($bucket, $key, $body);
+
+my $res2 = $client->get_object($bucket, $key);
+
+my $res3 = $client->head_object($bucket, $key);
+
+my $req1 = $res1->request;
+my $req2 = $res2->request;
+my $req3 = $res3->request;
+
+diag "test PUT request";
+is $req1->method, "PUT";
+is $req1->content, $body;
+is $req1->uri, "http://tmpfoobar.s3.amazonaws.com/dir/private.txt";
+
+diag "test GET request";
+is $req2->method, "GET";
+is $req2->uri, "http://tmpfoobar.s3.amazonaws.com/dir/private.txt";
+
+diag "test HEAD request";
+is $req3->method, "HEAD";
+is $req3->uri, "http://tmpfoobar.s3.amazonaws.com/dir/private.txt";
+
+diag "test GET request for list_objects";
+my $res4 = $client->list_objects($bucket, {prefix => "12012", delimiter => "/"});
+my $req4 = $res4->request;
+is $req4->method, "GET";
+is $req4->uri, "http://tmpfoobar.s3.amazonaws.com/?delimiter=%2F&prefix=12012";
+
+diag "test POST for delete_multiple_objects";
+my $res5 = $client->delete_multiple_objects( $bucket, 'key/one.txt', 'key/two.png' );
+my $req5 = $res5->request;
+is $req5->method, "POST";
+is $req5->uri, "http://tmpfoobar.s3.amazonaws.com/?delete";
+is $req5->header('Content-MD5'), 'pjGVehBgNtca8xN21pLCCA==';
+
+diag "test GET request with headers";
+my $res6 = $client->get_object($bucket, $key, {"X-Test-Header" => "Foo"});
+my $req6 = $res6->request;
+is $req6->method, "GET";
+is $req6->uri, "http://tmpfoobar.s3.amazonaws.com/dir/private.txt";
+is $req6->header("X-Test-Header"), "Foo";
+
+diag "test PUT request (copy) with headers";
+my $res7 = $client->copy_object($bucket, $key, $bucket, "copied.txt", {"x-amz-acl" => "public-read"});
+my $req7 = $res7->request;
+is $req7->method, "PUT";
+is $req7->uri, "http://tmpfoobar.s3.amazonaws.com/copied.txt";
+is $req7->header("x-amz-copy-source"), "tmpfoobar/dir/private.txt";
+is $req7->header("x-amz-acl"), "public-read";
+
+done_testing;
+
+package MockUA;
+
+sub new {
+    my $class = shift;
+    bless {}, $class;
+}
+
+sub request {
+    my $self = shift;
+    my $request = shift;
+    return MockResponse->new({request =>$request});
+}
+
+package MockResponse;
+
+sub new {
+    my ($class, $self) = @_;
+    bless $self, $class;
+}
+
+sub request {
+    my $self = shift;
+    return $self->{request};
+}
+
+;

--- a/xt/94_virtual_host.t
+++ b/xt/94_virtual_host.t
@@ -1,0 +1,108 @@
+use strict;
+use warnings;
+use Test::More;
+use Config::Tiny;
+
+use Amazon::S3::Thin;
+
+if (!$ENV{EXTENDED_TESTING}) {
+    plan skip_all => 'Skip functional test because it would call S3 APIs and charge real money. $ENV{EXTENDED_TESTING} is not set.';
+}
+
+my $debug = 1;
+my $use_https = 1;
+
+my $config_file = $ENV{HOME} . '/.aws/credentials';
+my $profile = 's3thin';
+my $bucket = $ENV{TEST_S3THIN_BUCKET} || 'dqneo-private-test';
+my $region = 'ap-northeast-1';
+my $host = "$bucket.s3.amazonaws.com";
+
+my $crd = Config::Tiny->read($config_file)->{$profile};
+
+my $arg = {
+    %$crd,
+    region       => $region,
+    secure       => $use_https,
+    debug        => $debug,
+    virtual_host => 1,
+};
+my $protocol = $use_https ? 'https' : 'http';
+my $client = Amazon::S3::Thin->new($arg);
+
+my $key =  "dir/s3test.txt";
+my $body = "hello amazon s3";
+
+# 0. HEAD to check existance
+# 1. DELETE
+# 2. PUT to create
+# 3. GET
+# 4. PUT to update
+# 5. DELETE
+my $res;
+my $req;
+diag "DELETE request";
+$res =  $client->delete_object($bucket, $key);
+$req = $res->request;
+is $res->code, 204;
+is $req->method, "DELETE";
+is $req->content, '';
+is $req->uri, "$protocol://$host/dir/s3test.txt";
+
+diag "HEAD request on non-existing object";
+$res = $client->head_object($bucket, $key);
+$req = $res->request;
+ok !$res->is_success, "is not success";
+is $res->code, 404;
+is $req->method, "HEAD";
+is $req->uri, "$protocol://$host/dir/s3test.txt";
+
+diag "GET request";
+$res = $client->get_object($bucket, $key);
+$req = $res->request;
+ok !$res->is_success, "is not success";
+is $res->code, 404;
+is $req->method, "GET";
+is $req->uri, "$protocol://$host/dir/s3test.txt";
+
+diag "PUT request";
+$res = $client->put_object($bucket, $key, $body);
+ok $res->is_success, "is_success";
+$req =  $res->request;
+is $req->method, "PUT";
+is $req->content, $body;
+is $req->uri, "$protocol://$host/dir/s3test.txt";
+
+diag "HEAD request";
+$res = $client->head_object($bucket, $key);
+ok $res->is_success, "is_success";
+$req =  $res->request;
+is $req->method, "HEAD";
+is $req->content, '';
+is $req->uri, "$protocol://$host/dir/s3test.txt";
+like $res->header("x-amz-request-id"), qr/.+/, "has proper headers";
+
+diag "COPY request";
+my $key2 = $key . "_copied";
+$res = $client->copy_object($bucket, $key, $bucket, $key2);
+ok $res->is_success, "is_success";
+$req =  $res->request;
+is $req->method, "PUT";
+
+
+diag "GET request";
+$res = $client->get_object($bucket, $key2);
+ok $res->is_success, "is_success";
+$req = $res->request;
+
+is $req->method, "GET";
+is $req->uri, "$protocol://$host/dir/s3test.txt_copied";
+
+diag "DELETE request";
+$res =  $client->delete_object($bucket, $key);
+ok $res->is_success, "is_success";
+
+$res =  $client->delete_object($bucket, $key2);
+ok $res->is_success, "is_success";
+
+done_testing;


### PR DESCRIPTION
Note: `virtual_host` is disabled by default for backward compatibility

AWS says:
> S3 buckets created after September 30, 2020 will support only virtual-hosted style requests.
Path-style requests will continue to be supported for buckets created on or before this date.

See also https://aws.amazon.com/jp/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/