### PR TITLE
fix an incorrect signature calculation in delete_multiple_objects()

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Amazon-S3-Thin
 
 {{$NEXT}}
 
+   - [bugfix] fix an incorrect signature calculation in delete_multiple_objects() (broken since version 0.20)
+
 0.27 2019-12-04T13:35:48Z
 
    - [core] support virtual-hosted style request

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -202,7 +202,8 @@ sub delete_multiple_objects {
     my ($self, $bucket, @keys) = @_;
 
     my $content = _build_xml_for_delete(@keys);
-    my $resource = $self->_resource($bucket, undef, 'delete');
+    # XXX: specify an empty string with `delete` query for calculating signature correctly in AWS::Signature4
+    my $resource = $self->_resource($bucket, undef, 'delete=');
     my $request = $self->_compose_request(
         'POST',
         $resource,

--- a/t/03_request.t
+++ b/t/03_request.t
@@ -51,7 +51,7 @@ diag "test POST for delete_multiple_objects";
 my $res5 = $client->delete_multiple_objects( $bucket, 'key/one.txt', 'key/two.png' );
 my $req5 = $res5->request;
 is $req5->method, "POST";
-is $req5->uri, "http://s3.ap-north-east-1.amazonaws.com/tmpfoobar/?delete";
+is $req5->uri, "http://s3.ap-north-east-1.amazonaws.com/tmpfoobar/?delete=";
 is $req5->header('Content-MD5'), 'pjGVehBgNtca8xN21pLCCA==';
 
 diag "test GET request with headers";

--- a/t/06_request_virtual_host.t
+++ b/t/06_request_virtual_host.t
@@ -52,7 +52,7 @@ diag "test POST for delete_multiple_objects";
 my $res5 = $client->delete_multiple_objects( $bucket, 'key/one.txt', 'key/two.png' );
 my $req5 = $res5->request;
 is $req5->method, "POST";
-is $req5->uri, "http://tmpfoobar.s3.amazonaws.com/?delete";
+is $req5->uri, "http://tmpfoobar.s3.amazonaws.com/?delete=";
 is $req5->header('Content-MD5'), 'pjGVehBgNtca8xN21pLCCA==';
 
 diag "test GET request with headers";

--- a/xt/95_delete_multiple_objects.t
+++ b/xt/95_delete_multiple_objects.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Test::More;
+use Config::Tiny;
+
+use Amazon::S3::Thin;
+
+if (!$ENV{EXTENDED_TESTING}) {
+    plan skip_all => 'Skip functional test because it would call S3 APIs and charge real money. $ENV{EXTENDED_TESTING} is not set.';
+}
+
+my $debug = 1;
+my $use_https = 1;
+
+my $config_file = $ENV{HOME} . '/.aws/credentials';
+my $profile = 's3thin';
+my $bucket = $ENV{TEST_S3THIN_BUCKET} || 'dqneo-private-test';
+my $region = 'ap-northeast-1';
+my $host = "s3.$region.amazonaws.com";
+
+my $crd = Config::Tiny->read($config_file)->{$profile};
+
+my $arg = {
+    %$crd,
+    region => $region,
+    secure => $use_https,
+    debug  => $debug,
+};
+my $protocol = $use_https ? 'https' : 'http';
+my $client = Amazon::S3::Thin->new($arg);
+
+my $key1 =  "dir/s3test_1.txt";
+my $key2 =  "dir/s3test_2.txt";
+my $body = "hello amazon s3";
+
+my $res;
+my $req;
+
+diag "PUT request";
+$res = $client->put_object($bucket, $key1, $body);
+ok $res->is_success, "is_success";
+$res = $client->put_object($bucket, $key2, $body);
+ok $res->is_success, "is_success";
+
+diag "DELETE request";
+$res =  $client->delete_multiple_objects($bucket, $key1, $key2);
+ok $res->is_success, "is_success";
+$req =  $res->request;
+is $req->method, "POST";
+is $req->content, "<Delete><Quiet>true</Quiet><Object><Key>$key1</Key></Object><Object><Key>$key2</Key></Object></Delete>";
+is $req->uri, "$protocol://$host/$bucket/?delete=";
+
+diag "HEAD request";
+$res = $client->head_object($bucket, $key1);
+ok $res->is_error, "is_error";
+$res = $client->head_object($bucket, $key2);
+ok $res->is_error, "is_error";
+
+done_testing;


### PR DESCRIPTION
There was a bug in `delete_multiple_objects()` since version 0.20.

`AWS::Signature4` uses `URI` to parse query string by calling `query_form`:
https://metacpan.org/source/LDS/AWS-Signature4-1.02/lib/AWS/Signature4.pm#L306

But `URI->query_form` doesn't return key and value when passed `/?delete`, so we have to pass `/?delete=` in `delete_multiple_objects()`.
```
0> use URI
1> URI->new('/?delete')->query_form
2> URI->new('/?delete=')->query_form
$res[0] = [
  'delete',
  ''
]
```