### PR TITLE
Support extra credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,24 @@ Amazon::S3::Thin - A thin, lightweight, low-level Amazon S3 client
 
     use Amazon::S3::Thin;
 
+    # Pass in explicit credentials
     my $s3client = Amazon::S3::Thin->new({
           aws_access_key_id     => $aws_access_key_id,
           aws_secret_access_key => $aws_secret_access_key,
           aws_session_token     => $aws_session_token, # optional
           region                => $region, # e.g. 'ap-northeast-1'
         });
+
+    # Get credentials from environment
+    my $s3client = Amazon::S3::Thin->new({region => $region, credential_provider => 'env'});
+
+    # Get credentials from instance metadata
+    my $s3client = Amazon::S3::Thin->new({
+        region              => $region,
+        credential_provider => 'metadata',
+        version             => 2,         # optional (default 2)
+        role                => 'my-role', # optional
+      });
 
     my $bucket = "mybucket";
     my $key = "dir/file.txt";

--- a/eg/s3
+++ b/eg/s3
@@ -39,8 +39,9 @@ sub run {
     $p->getoptionsfromarray(
         \@args,
         "p|profile=s"   => \(my $profile = "default"),
+        "r|region=s"    => \(my $region),
         "h|help"        => \(my $help),
-        "version"     => \(my $version),
+        "version"       => \(my $version),
         "v|verbose"     => \($self->{verbose}),
     );
     if ($version) {
@@ -55,14 +56,38 @@ sub run {
     # https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
     my $cred_file = $ENV{HOME} . "/.aws/credentials";
     my $config_file = $ENV{HOME} . "/.aws/config";
-    my $crd = Config::Tiny->read($cred_file)->{$profile};
-    my $config = Config::Tiny->read($config_file)->{$profile};
-    my $opt = +{
-        aws_access_key_id => $crd->{aws_access_key_id},
-        aws_secret_access_key => $crd->{aws_secret_access_key},
-        region => $config->{region},
-    };
-    $self->{thin_client} = Amazon::S3::Thin->new($opt);
+
+    if (-f $config_file and !defined $region) {
+        my $config = Config::Tiny->read($config_file)->{$profile};
+        $region = $config->{region};
+    }
+
+    if (-f $cred_file) {
+        my $crd = Config::Tiny->read($cred_file)->{$profile};
+
+        my $opt = +{
+            aws_access_key_id     => $crd->{aws_access_key_id},
+            aws_secret_access_key => $crd->{aws_secret_access_key},
+            region                => $region
+        };
+        $self->{thin_client} = Amazon::S3::Thin->new($opt);
+    }
+    elsif (defined $ENV{AWS_ACCESS_KEY_ID} and defined $ENV{AWS_SECRET_ACCESS_KEY}) {
+        my $opt = +{
+            credential_provider => 'env',
+            region              => $region
+        };
+        $self->{thin_client} = Amazon::S3::Thin->new($opt);
+    }
+    else {
+        my $opt = +{
+            credential_provider => 'metadata',
+            version             => 1,
+            region              => $region
+        };
+        $self->{thin_client} = Amazon::S3::Thin->new($opt);
+    }
+
     my $subcmd = shift @args;
     if (!$subcmd) {
         $self->help();

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -18,8 +18,8 @@ sub new {
     my $class = shift;
     my $self  = shift;
 
-    # Jump through some hoops to maintain backwards compatability here. If we don't
-    # get passed any credentials as arguments then try another method
+    # If we have an explicitly-configured credential provider then use that here, otherwise
+    # existing behaviour will be followed
     if ($self->{credential_provider} and $self->{credential_provider} eq 'env') {
         $self->{credentials} = Amazon::S3::Thin::Credentials->from_env;
     }

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -477,13 +477,30 @@ It can receive the following arguments:
 
 =over 4
 
-=item * C<aws_access_key_id> (B<REQUIRED>) - an access key id
-of your credentials.
+=item * C<credential_provider> (B<default: credentials>) - specify where to source credentials from. Options are:
 
-=item * C<aws_secret_access_key> (B<REQUIRED>) - an secret access key
- of your credentials.
+=over 2
+
+=item * C<credentials> - existing behaviour, pass in credentials via C<aws_access_key_id> and C<aws_secret_access_key>
+
+=item * C<env> - fetch credentials from environment variables
+
+=item * C<metadata> - fetch credentials from EC2 instance metadata service
+
+=back
 
 =item * C<region> - (B<REQUIRED>) region of your buckets you access- (currently used only when signature version is 4)
+
+=item * C<aws_access_key_id> (B<REQUIRED [provider: credentials]>) - an access key id
+of your credentials.
+
+=item * C<aws_secret_access_key> (B<REQUIRED [provider: credentials]>) - an secret access key
+ of your credentials.
+
+=item * C<version> (B<OPTIONAL [provider: metadata]>) - version of metadata service to use, either 1 or 2.
+L<read more|https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html>
+
+=item * C<role> (B<OPTIONAL [provider: metadata]>) - IAM instance role to use, otherwise the first is selected
 
 =item * C<secure> - whether to use https or not. Default is 0 (http).
 

--- a/lib/Amazon/S3/Thin/Credentials.pm
+++ b/lib/Amazon/S3/Thin/Credentials.pm
@@ -20,12 +20,27 @@ Amazon::S3::Thin::Credentials - AWS credentials data container
 
 =head1 DESCRIPTION
 
-This module contains aws credentials and provide getters to the data.
+This module contains AWS credentials and provide getters to the data.
+
+    # Load from arguments
+    my $creds = Amazon::S3::Thin::Credentials->new($access_key, $secret_key, $session_token);
+
+    # Load from environment
+    my $creds = Amazon::S3::Thin::Credentials->from_env
+
+    # Load from instance profile
+    my $creds = Amazon::S3::Thin::Credentials->from_instance(role => 'foo', version => 2);
 
 =cut
 
 use strict;
 use warnings;
+
+use Carp;
+use JSON::PP;
+use LWP::UserAgent;
+
+my $JSON = JSON::PP->new->utf8->canonical;
 
 sub new {
     my ($class, $key, $secret, $session_token) = @_;
@@ -35,6 +50,62 @@ sub new {
         session_token => $session_token,
     };
     return bless $self, $class;
+}
+
+sub from_env {
+    my ($class) = @_;
+
+    # Check the environment is configured
+    croak "AWS_ACCESS_KEY_ID is not set" unless $ENV{AWS_ACCESS_KEY_ID};
+    croak "AWS_SECRET_ACCESS_KEY is not set" unless $ENV{AWS_SECRET_ACCESS_KEY};
+
+    my $self = {
+        key => $ENV{AWS_ACCESS_KEY_ID},
+        secret => $ENV{AWS_SECRET_ACCESS_KEY},
+        session_token => $ENV{AWS_SESSION_TOKEN}
+    };
+    return bless $self, $class;
+}
+
+sub from_metadata {
+    my ($class, $args) = @_;
+
+    my $ua = LWP::UserAgent->new;
+
+    # Default to the more secure v2 metadata provider
+    if (!$args->{version} or $args->{version} != 1) {
+        my $res = $ua->get('http://169.254.169.254/latest/api/token', {
+            'X-aws-ec2-metadata-token-ttl-seconds' => 90
+        });
+        croak 'Error retreiving v2 token from metadata provider: ' . $res->decoded_content
+            unless $res->is_success;
+
+        $ua->default_header('X-aws-ec2-metadata-token' => $res->decoded_content);
+    }
+
+    return _instance_metadata($ua, $args->{role});
+}
+
+sub _instance_metadata {
+    my ($ua, $role) = @_;
+
+    my $res = $ua->get('http://169.254.169.254/latest/meta-data/iam/security-credentials');
+    croak 'Error querying metadata service for roles: ' . $res->decoded_content unless $res->is_success;
+
+    my @roles = split /\n/, $res->decoded_content;
+    return unless @roles > 0;
+
+    my $target_role = (defined $role and grep { $role eq $_ } @roles)
+        ? $role
+        : $roles[0];
+
+    my $cred = $ua->get('http://169.254.169.254/latest/meta-data/iam/security-credentials/' / $target_role);
+    croak 'Error querying metadata service for credentials: ' . $cred->decoded_content unless $cred->is_success;
+
+    my $obj = eval { decode_json $cred->decoded_content };
+    croak "Invalid data returned from metadata service: $@" if $@;
+
+    return __PACKAGE__->new($obj->{AccessKeyId}, $obj->{SecretAccessKey}, $obj->{Token});
 }
 
 =head2 access_key_id()

--- a/t/01_new.t
+++ b/t/01_new.t
@@ -43,4 +43,18 @@ my %crd = (
     isa_ok($s3client->{signer}, 'Amazon::S3::Thin::Signer::V4', 'new v4');
 }
 
+BEGIN {
+    $ENV{AWS_ACCESS_KEY_ID} = 'dummy';
+    $ENV{AWS_SECRET_ACCESS_KEY} = 'dummy';
+}
+{
+    diag "test from_env";
+    my $arg = +{
+        region => 'ap-northeast-1',
+        credential_provider => 'env'
+    };
+    my $s3client = Amazon::S3::Thin->new($arg);
+    isa_ok($s3client->{signer}, 'Amazon::S3::Thin::Signer::V4', 'new v4');
+}
+
 done_testing;


### PR DESCRIPTION
This PR allows fetching credentials from environment variables or an EC2-compatible metadata provider.

I'd probably have preferred to encapsulate the logic in `Amazon::S3::Thin::Credentials` to have it just select the right credentials based on the [standard priority order](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) but didn't want to cause any breakage for existing library users. This way I also didn't need to implement all variations, only the ones I'm interested in 😉 

Feedback welcome 