### PR TITLE
Fix a behavior of creating a session token with IMDSv2

### DIFF
--- a/lib/Amazon/S3/Thin/Credentials.pm
+++ b/lib/Amazon/S3/Thin/Credentials.pm
@@ -103,9 +103,7 @@ sub from_metadata {
 
     # Default to the more secure v2 metadata provider
     if (!$args->{version} or $args->{version} != 1) {
-        my $res = $ua->get('http://169.254.169.254/latest/api/token', {
-            'X-aws-ec2-metadata-token-ttl-seconds' => 90
-        });
+        my $res = $ua->put('http://169.254.169.254/latest/api/token', 'X-aws-ec2-metadata-token-ttl-seconds' => 90);
         croak 'Error retreiving v2 token from metadata provider: ' . $res->decoded_content
             unless $res->is_success;
 

--- a/lib/Amazon/S3/Thin/Credentials.pm
+++ b/lib/Amazon/S3/Thin/Credentials.pm
@@ -99,7 +99,7 @@ it is the default here.
 sub from_metadata {
     my ($class, $args) = @_;
 
-    my $ua = LWP::UserAgent->new;
+    my $ua = $args->{ua} // LWP::UserAgent->new;
 
     # Default to the more secure v2 metadata provider
     if (!$args->{version} or $args->{version} != 1) {

--- a/lib/Amazon/S3/Thin/Credentials.pm
+++ b/lib/Amazon/S3/Thin/Credentials.pm
@@ -29,7 +29,7 @@ This module contains AWS credentials and provide getters to the data.
     my $creds = Amazon::S3::Thin::Credentials->from_env;
 
     # Load from instance profile
-    my $creds = Amazon::S3::Thin::Credentials->from_instance(role => 'foo', version => 2);
+    my $creds = Amazon::S3::Thin::Credentials->from_metadata(role => 'foo', version => 2);
 
 =cut
 
@@ -89,7 +89,7 @@ In November 2019 AWS released L<version 2|https://aws.amazon.com/blogs/security/
 is more secure against Server Side Request Forgery attacks. Using v2 is highly recommended thus
 it is the default here.
 
-    my $creds = Amazon::S3::Thin::Credentials->from_instance(
+    my $creds = Amazon::S3::Thin::Credentials->from_metadata(
         role => 'foo',      # The name of the IAM role on the instance
         version => 2        # Metadata service version - either 1 or 2
     );

--- a/t/02_credentials_metadata.t
+++ b/t/02_credentials_metadata.t
@@ -36,6 +36,35 @@ my $arg = +{
   is $credentials->session_token, 'DUMMY-TOKEN';
 }
 
+{
+  diag "test when a role name is specified";
+
+  my $ua = MockUA->new;
+  my $credentials = Amazon::S3::Thin::Credentials->from_metadata(+{
+    %$arg,
+    ua      => $ua,
+    role    => 'DUMMY-INSTANCE-PROFILE-3',
+    version => 1,
+  });
+
+  is_deeply $ua->requests, [
+    {
+      method  => 'GET',
+      uri     => 'http://169.254.169.254/latest/meta-data/iam/security-credentials',
+      headers => {},
+    },
+    {
+      method => 'GET',
+      uri     => 'http://169.254.169.254/latest/meta-data/iam/security-credentials/DUMMY-INSTANCE-PROFILE-3',
+      headers => {},
+    },
+  ];
+
+  is $credentials->access_key_id, 'DUMMY-ACCESS-KEY';
+  is $credentials->secret_access_key, 'DUMMY-SECRET-ACCESS-KEY';
+  is $credentials->session_token, 'DUMMY-TOKEN';
+}
+
 done_testing;
 
 package MockUA;

--- a/t/02_credentials_metadata.t
+++ b/t/02_credentials_metadata.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+use Amazon::S3::Thin::Credentials;
+use Test::More;
+
+my $arg = +{
+  credential_provider => 'metadata',
+  region              => 'ap-northeast-1',
+};
+
+{
+  diag "IMDSv1";
+
+  my $ua = MockUA->new;
+  my $credentials = Amazon::S3::Thin::Credentials->from_metadata(+{
+    %$arg,
+    ua      => $ua,
+    version => 1,
+  });
+
+  is_deeply $ua->requests, [
+    {
+      method  => 'GET',
+      uri     => 'http://169.254.169.254/latest/meta-data/iam/security-credentials',
+      headers => {},
+    },
+    {
+      method => 'GET',
+      uri     => 'http://169.254.169.254/latest/meta-data/iam/security-credentials/DUMMY-INSTANCE-PROFILE-1',
+      headers => {},
+    },
+  ];
+
+  is $credentials->access_key_id, 'DUMMY-ACCESS-KEY';
+  is $credentials->secret_access_key, 'DUMMY-SECRET-ACCESS-KEY';
+  is $credentials->session_token, 'DUMMY-TOKEN';
+}
+
+done_testing;
+
+package MockUA;
+
+sub new {
+  my $class = shift;
+  bless { requests => [] }, $class;
+}
+
+sub get {
+  my ($self, $uri, %form) = @_;
+
+  my $request = +{
+    method  => 'GET',
+    uri     => $uri,
+    headers => \%form,
+  };
+
+  push @{$self->{requests}}, $request;
+
+  return MockResponse->new({ request => $request });
+}
+
+sub requests {
+  my $self = shift;
+  
+  $self->{requests};
+}
+
+package MockResponse;
+
+sub new {
+  my ($class, $self) = @_;
+  bless $self, $class;
+}
+
+sub is_success { !!1; }
+
+sub decoded_content {
+  my $self = shift;
+
+  my $latest_uri = $self->{request}->{uri};
+
+  if ($latest_uri =~ qr{/latest/api/token$}) {
+    return 'DUMMY-METADATA-TOKEN';
+  } elsif ($latest_uri =~ qr{/latest/meta-data/iam/security-credentials$}) {
+    return <<'TEXT';
+DUMMY-INSTANCE-PROFILE-1
+DUMMY-INSTANCE-PROFILE-2
+DUMMY-INSTANCE-PROFILE-3
+TEXT
+  } elsif ($latest_uri =~ qr{/latest/meta-data/iam/security-credentials/.+$}) {
+    return <<'JSON';
+{
+  "Code" : "Success",
+  "LastUpdated" : "2022-08-01T00:00:00Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "DUMMY-ACCESS-KEY",
+  "SecretAccessKey" : "DUMMY-SECRET-ACCESS-KEY",
+  "Token" : "DUMMY-TOKEN",
+  "Expiration" : "2022-08-01T12:00:00Z"
+}
+JSON
+  }
+}


### PR DESCRIPTION
When the parameter `credential_provider => 'metadata'` is given at initialization, some requests are sent to use IMDS (Instance Metadata Service) v1 or IMDSv2 to obtain the access key and secret key.

When we use IMDSv2, we must use a `PUT` request to create a session token, but this module uses a `GET` request. Furthermore, the request header is incorrectly specified. These are causing an error like this:

```console
sh-4.2$ carton exec -- perl ./read-file-from-s3.pl BUCKET_NAME hello.txt
Use of uninitialized value $v in concatenation (.) or string at /home/ssm-user/amazon-s3-thin-demo/local/lib/perl5/Net/HTTP/Methods.pm line 167.
Error retreiving v2 token from metadata provider:  at /home/ssm-user/amazon-s3-thin-demo/local/lib/perl5/Amazon/S3/Thin.pm line 27.
```

To reproduce this problem easily, you can use https://github.com/masawada/amazon-s3-thin-demo.

See this URL for more details: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html