### PR TITLE
Fetch credentials from ECS task role

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Amazon::S3::Thin - A thin, lightweight, low-level Amazon S3 client
         role                => 'my-role', # optional
       });
 
+    # Get credentials from ECS task role
+    my $s3client = Amazon::S3::Thin->new({
+        region              => $region,
+        credential_provider => 'ecs_container',
+      });
+
     my $bucket = "mybucket";
     my $key = "dir/file.txt";
     my $response;

--- a/eg/s3
+++ b/eg/s3
@@ -79,6 +79,13 @@ sub run {
         };
         $self->{thin_client} = Amazon::S3::Thin->new($opt);
     }
+    elsif (defined $ENV{AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}) {
+        my $opt = +{
+            credential_provider => 'ecs_container',
+            region              => $region
+        };
+        $self->{thin_client} = Amazon::S3::Thin->new($opt);
+    }
     else {
         my $opt = +{
             credential_provider => 'metadata',

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -26,6 +26,9 @@ sub new {
     elsif ($self->{credential_provider} and $self->{credential_provider} eq 'metadata') {
         $self->{credentials} = Amazon::S3::Thin::Credentials->from_metadata($self);
     }
+    elsif ($self->{credential_provider} and $self->{credential_provider} eq 'ecs_container') {
+        $self->{credentials} = Amazon::S3::Thin::Credentials->from_ecs_container($self);
+    }
     else {
         # check existence of credentials
         croak "No aws_access_key_id"     unless $self->{aws_access_key_id};
@@ -395,6 +398,12 @@ Amazon::S3::Thin - A thin, lightweight, low-level Amazon S3 client
       role                => 'my-role', # optional
     });
 
+  # Get credentials from ECS task role
+  my $s3client = Amazon::S3::Thin->new({
+      region              => $region,
+      credential_provider => 'ecs_container',
+    });
+
   my $bucket = "mybucket";
   my $key = "dir/file.txt";
   my $response;
@@ -486,6 +495,8 @@ It can receive the following arguments:
 =item * C<env> - fetch credentials from environment variables
 
 =item * C<metadata> - fetch credentials from EC2 instance metadata service
+
+=item * C<ecs_container> - fetch credentials from ECS task role
 
 =back
 

--- a/t/01_new.t
+++ b/t/01_new.t
@@ -43,6 +43,29 @@ my %crd = (
     isa_ok($s3client->{signer}, 'Amazon::S3::Thin::Signer::V4', 'new v4');
 }
 
+{
+    diag "test from_ecs_container";
+
+    local $ENV{AWS_CONTAINER_CREDENTIALS_RELATIVE_URI} = '/foobar';
+
+    my $arg = +{
+        credential_provider => 'ecs_container',
+        region => 'ap-northeast-1',
+        ua => MockUA->new,
+    };
+    my $s3client = Amazon::S3::Thin->new($arg);
+    isa_ok($s3client->{signer}, 'Amazon::S3::Thin::Signer::V4', 'new v4');
+
+    package MockUA;
+    sub new { bless {}, shift; }
+    sub get { return MockResponse->new; };
+
+    package MockResponse;
+    sub new { bless {}, shift; }
+    sub is_success { !!1; }
+    sub decoded_content { '{"AccessKeyId": "Key", "SecretAccessKey": "Secret", "Token": "Token"}'; }
+}
+
 BEGIN {
     $ENV{AWS_ACCESS_KEY_ID} = 'dummy';
     $ENV{AWS_SECRET_ACCESS_KEY} = 'dummy';

--- a/t/02_credentials_ecs_container.t
+++ b/t/02_credentials_ecs_container.t
@@ -1,0 +1,132 @@
+use strict;
+use warnings;
+use Amazon::S3::Thin::Credentials;
+use Test::More;
+
+my $arg = +{
+    credential_provider => 'ecs_container',
+    region              => 'ap-northeast-1',
+};
+
+{
+    diag "retrieve credentials from the ECS task role";
+
+    local $ENV{AWS_CONTAINER_CREDENTIALS_RELATIVE_URI} = '/foobar';
+
+    my $ua = MockUA->new;
+    my $credentials = Amazon::S3::Thin::Credentials->from_ecs_container(+{ ua => $ua });
+
+    is_deeply $ua->requests, [
+        {
+            method  => 'GET',
+            uri     => 'http://169.254.170.2/foobar',
+        },
+    ];
+
+    is $credentials->access_key_id, 'DUMMY-ACCESS-KEY';
+    is $credentials->secret_access_key, 'DUMMY-SECRET-ACCESS-KEY';
+    is $credentials->session_token, 'DUMMY-TOKEN';
+}
+
+{
+    diag "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set";
+
+    my $ua = MockUA->new;
+
+    eval {
+        my $credentials = Amazon::S3::Thin::Credentials->from_ecs_container(+{ ua => $ua });
+    };
+
+    like $@, qr/The environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set/;
+}
+
+{
+    diag "request failed";
+
+    local $ENV{AWS_CONTAINER_CREDENTIALS_RELATIVE_URI} = '/internal_server_error';
+
+    my $ua = MockUA->new;
+    eval {
+        my $credentials = Amazon::S3::Thin::Credentials->from_ecs_container(+{ ua => $ua });
+    };
+
+    like $@, qr/Error retrieving container credentials/;
+}
+
+{
+    diag "returned content is not JSON";
+
+    local $ENV{AWS_CONTAINER_CREDENTIALS_RELATIVE_URI} = '/not_json';
+
+    my $ua = MockUA->new;
+    eval {
+        my $credentials = Amazon::S3::Thin::Credentials->from_ecs_container(+{ ua => $ua });
+    };
+
+    like $@, qr/Invalid data returned: /;
+}
+
+done_testing;
+
+package MockUA;
+
+sub new {
+    my $class = shift;
+    bless { requests => [] }, $class;
+}
+
+sub get {
+    my ($self, $uri) = @_;
+    
+    my $request = {
+        method  => 'GET',
+        uri     => $uri,
+    };
+    
+    push @{$self->{requests}}, $request;
+    
+    return MockResponse->new({ request => $request });
+}
+
+sub requests {
+    my $self = shift;
+    
+    $self->{requests};
+}
+
+package MockResponse;
+
+sub new {
+    my ($class, $self) = @_;
+    bless $self, $class;
+}
+
+sub is_success {
+    my $self = shift;
+    
+    my $latest_uri = $self->{request}->{uri};
+    
+    return $latest_uri !~ qr{/internal_server_error$};
+}
+
+sub decoded_content {
+    my $self = shift;
+    
+    my $latest_uri = $self->{request}->{uri};
+    
+    if ($latest_uri =~ qr{/foobar$}) {
+        return <<'JSON';
+{
+  "AccessKeyId" : "DUMMY-ACCESS-KEY",
+  "Expiration" : "2022-08-01T12:00:00Z",
+  "RoleArn" : "DUMMY-TASK-ROLE-ARN",
+  "SecretAccessKey" : "DUMMY-SECRET-ACCESS-KEY",
+  "Token" : "DUMMY-TOKEN"
+}
+JSON
+    } elsif ($latest_uri =~ qr{/internal_server_error$}) {
+        return '';
+    } else {
+        return 'not json';
+    }
+}


### PR DESCRIPTION
In an ECS container, credentials can be retrieved from the task role attached to the container.

An environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is set in the container. `GET 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` returns credentials.

See this URL for more details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html

To check the behavior, you can use this: https://github.com/masawada/amazon-s3-thin-demo/pull/1