### PR TITLE
Add custom endpoint support for S3-compatible services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Amazon::S3::Thin - A thin, lightweight, low-level Amazon S3 client
         credential_provider => 'ecs_container',
       });
 
+    # Use S3-compatible services (e.g. MinIO, Wasabi)
+    my $s3client = Amazon::S3::Thin->new({
+        aws_access_key_id     => $aws_access_key_id,
+        aws_secret_access_key => $aws_secret_access_key,
+        endpoint              => 'http://localhost:9000',
+      });
+
     my $bucket = "mybucket";
     my $key = "dir/file.txt";
     my $response;
@@ -129,6 +136,10 @@ are 2 and 4. Default is 4.
 - `debug` - debug option. Default is 0 (false). 
 If set 1, contents of HTTP request and response are shown on stderr
 - `virtual_host` - whether to use virtual-hosted style request format. Default is 0 (path-style).
+- `endpoint` - a custom endpoint URL for S3-compatible services (e.g. MinIO, Wasabi).
+If set, requests will be sent to this endpoint instead of AWS S3.
+The endpoint should include the protocol (e.g. `http://localhost:9000`).
+When `endpoint` is set without `region`, the region defaults to `us-east-1`.
 
 # ACCESSORS
 

--- a/lib/Amazon/S3/Thin.pm
+++ b/lib/Amazon/S3/Thin.pm
@@ -54,9 +54,10 @@ sub new {
     $self->virtual_host(0)          unless defined $self->virtual_host;
 
     $self->{signature_version} = 4  unless defined $self->{signature_version};
-    if ($self->{signature_version} == 4 && ! $self->{region}) {
+    if ($self->{signature_version} == 4 && ! $self->{region} && ! $self->{endpoint}) {
         croak "Please set region when you use signature v4";
     }
+    $self->{region} ||= 'us-east-1' if $self->{endpoint};
 
     $self->{signer} = $self->_load_signer($self->{signature_version});
     return $self;
@@ -296,10 +297,17 @@ sub generate_presigned_post {
         my $resource = $self->_resource($bucket);
         my $protocol = $self->secure ? 'https' : 'http';
 
+        my $url;
+        if ($self->{endpoint}) {
+            $url = $resource->to_endpoint_url($self->{endpoint});
+        } elsif ($self->virtual_host) {
+            $url = $resource->to_virtual_hosted_style_url($protocol);
+        } else {
+            $url = $resource->to_path_style_url($protocol, $self->{region});
+        }
+
         return {
-            ($self->virtual_host
-                ? (url => $resource->to_virtual_hosted_style_url($protocol))
-                : (url => $resource->to_path_style_url($protocol, $self->{region}))),
+            url => $url,
             fields => $self->{signer}->_generate_presigned_post(
                 $bucket, $key, $fields, $conditions, $expires_in
             ),
@@ -349,7 +357,9 @@ sub _compose_request {
 
     my $url;
 
-    if ($self->{signature_version} == 4) {
+    if ($self->{endpoint}) {
+        $url = $resource->to_endpoint_url($self->{endpoint});
+    } elsif ($self->{signature_version} == 4) {
         if ($self->virtual_host) {
             $url = $resource->to_virtual_hosted_style_url($protocol);
         } else {
@@ -525,6 +535,11 @@ are 2 and 4. Default is 4.
 If set 1, contents of HTTP request and response are shown on stderr
 
 =item * C<virtual_host> - whether to use virtual-hosted style request format. Default is 0 (path-style).
+
+=item * C<endpoint> - a custom endpoint URL for S3-compatible services (e.g. MinIO, Wasabi).
+If set, requests will be sent to this endpoint instead of AWS S3.
+The endpoint should include the protocol (e.g. C<http://localhost:9000>).
+When C<endpoint> is set without C<region>, the region defaults to C<us-east-1>.
 
 =back
 

--- a/lib/Amazon/S3/Thin/Resource.pm
+++ b/lib/Amazon/S3/Thin/Resource.pm
@@ -47,6 +47,16 @@ sub to_virtual_hosted_style_url {
     );
 }
 
+sub to_endpoint_url {
+    my $self = shift;
+    my $endpoint = shift;
+
+    # remove trailing slash from endpoint
+    $endpoint =~ s{/+$}{};
+
+    return $endpoint . '/' . $self->{bucket} . '/' . $self->key_and_query;
+}
+
 sub _region_specific_host {
     my $self = shift;
     my $region = shift;

--- a/t/08_request_endpoint.t
+++ b/t/08_request_endpoint.t
@@ -1,0 +1,149 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Amazon::S3::Thin;
+use Test::More;
+
+my $arg = +{
+    aws_access_key_id     => "dummy",
+    aws_secret_access_key => "dummy",
+    region => 'us-east-1',
+    endpoint => 'http://localhost:9000',
+};
+
+$arg->{ua} = MockUA->new;
+my $client = Amazon::S3::Thin->new($arg);
+
+my $bucket = "tmpfoobar";
+my $key =  "dir/private.txt";
+my $body = "hello world";
+
+my $res1 = $client->put_object($bucket, $key, $body);
+my $res2 = $client->get_object($bucket, $key);
+my $res3 = $client->head_object($bucket, $key);
+my $res4 = $client->delete_object($bucket, $key);
+
+my $req1 = $res1->request;
+my $req2 = $res2->request;
+my $req3 = $res3->request;
+my $req4 = $res4->request;
+
+diag "test PUT request with custom endpoint";
+is $req1->method, "PUT";
+is $req1->content, $body;
+is $req1->uri, "http://localhost:9000/tmpfoobar/dir/private.txt";
+
+diag "test GET request with custom endpoint";
+is $req2->method, "GET";
+is $req2->uri, "http://localhost:9000/tmpfoobar/dir/private.txt";
+
+diag "test HEAD request with custom endpoint";
+is $req3->method, "HEAD";
+is $req3->uri, "http://localhost:9000/tmpfoobar/dir/private.txt";
+
+diag "test DELETE request with custom endpoint";
+is $req4->method, "DELETE";
+is $req4->uri, "http://localhost:9000/tmpfoobar/dir/private.txt";
+
+diag "test GET request for list_objects with custom endpoint";
+my $res5 = $client->list_objects($bucket, {prefix => "12012", delimiter => "/"});
+my $req5 = $res5->request;
+is $req5->method, "GET";
+is $req5->uri, "http://localhost:9000/tmpfoobar/?delimiter=%2F&prefix=12012";
+
+diag "test POST for delete_multiple_objects with custom endpoint";
+my $res6 = $client->delete_multiple_objects( $bucket, 'key/one.txt', 'key/two.png' );
+my $req6 = $res6->request;
+is $req6->method, "POST";
+is $req6->uri, "http://localhost:9000/tmpfoobar/?delete=";
+is $req6->header('Content-MD5'), 'pjGVehBgNtca8xN21pLCCA==';
+
+diag "test PUT request (copy) with custom endpoint";
+my $res7 = $client->copy_object($bucket, $key, $bucket, "copied.txt", {"x-amz-acl" => "public-read"});
+my $req7 = $res7->request;
+is $req7->method, "PUT";
+is $req7->uri, "http://localhost:9000/tmpfoobar/copied.txt";
+is $req7->header("x-amz-copy-source"), "tmpfoobar/dir/private.txt";
+is $req7->header("x-amz-acl"), "public-read";
+
+subtest 'endpoint with trailing slash' => sub {
+    my $client2 = Amazon::S3::Thin->new({
+        aws_access_key_id     => "dummy",
+        aws_secret_access_key => "dummy",
+        region   => 'us-east-1',
+        endpoint => 'http://localhost:9000/',
+        ua       => MockUA->new,
+    });
+    my $res = $client2->get_object($bucket, $key);
+    is $res->request->uri, "http://localhost:9000/tmpfoobar/dir/private.txt",
+        "trailing slash in endpoint is handled correctly";
+};
+
+subtest 'endpoint without region defaults to us-east-1' => sub {
+    my $client3 = Amazon::S3::Thin->new({
+        aws_access_key_id     => "dummy",
+        aws_secret_access_key => "dummy",
+        endpoint => 'https://minio.example.com',
+        ua       => MockUA->new,
+    });
+    my $res = $client3->get_object($bucket, $key);
+    is $res->request->uri, "https://minio.example.com/tmpfoobar/dir/private.txt",
+        "endpoint works without explicit region";
+};
+
+subtest 'endpoint with custom port' => sub {
+    my $client4 = Amazon::S3::Thin->new({
+        aws_access_key_id     => "dummy",
+        aws_secret_access_key => "dummy",
+        region   => 'us-east-1',
+        endpoint => 'http://192.168.1.100:9000',
+        ua       => MockUA->new,
+    });
+    my $res = $client4->get_object($bucket, $key);
+    is $res->request->uri, "http://192.168.1.100:9000/tmpfoobar/dir/private.txt",
+        "endpoint with IP address and port works correctly";
+};
+
+done_testing;
+
+package MockUA;
+
+sub new {
+    my $class = shift;
+    bless {}, $class;
+}
+
+sub request {
+    my $self = shift;
+    my $request = shift;
+    return MockResponse->new({request =>$request});
+}
+
+package MockResponse;
+
+sub new {
+    my ($class, $self) = @_;
+    bless $self, $class;
+}
+
+sub request {
+    my $self = shift;
+    return $self->{request};
+}
+
+sub code {
+    my $self = shift;
+    return 200;
+}
+
+sub content {
+    my $self = shift;
+    return <<'XML';
+<CopyObjectResult>
+    <LastModified>2009-10-28T22:32:00</LastModified>
+    <ETag>"9b2cf535f27731c974343645a3985328"</ETag>
+<CopyObjectResult>
+XML
+}
+
+;


### PR DESCRIPTION
In this pull request, I have added custom endpoint support for S3-compatible services.

Currently, Amazon::S3::Thin has its request destination fixed to the AWS S3 hostname (s3.amazonaws.com), which prevents sending requests to S3-compatible services such as MinIO, Wasabi, and DigitalOcean Spaces.

Furthermore, when generating pre-signed URLs, the AWS hostname is embedded into the URL. Consequently, S3-compatible services cannot obtain the correct URL, causing signature verification to fail.

Therefore, I added an endpoint option to the constructor. If specified, all request URLs will be generated based on that endpoint.

Feedback welcome!
